### PR TITLE
Add missing CAT localization keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.DS_Store

--- a/locales/ca/translation.json
+++ b/locales/ca/translation.json
@@ -1,8 +1,57 @@
 {
+  "nav": {
+    "map": "Mapa",
+    "community": "Comunitat",
+    "login": "Entra"
+  },
   "header": {
     "title": "KATUMA",
-    "slogan": "Compra directament a productores agroecològiques de proximitat",
-    "subtitle": "Consumeix productes de proximitat i participa d'un model sostenible amb beneficis socioeconòmics per a la comunitat"
+    "slogan": "Compra directament a productores de proximitat",
+    "subtitle": "Consumeix productes de proximitat i participa d'un model sostenible amb beneficis socioeconòmics per a la comunitat."
+  },
+  "participate": {
+    "title": "Entre totes podem canviar les regles del consum",
+    "body": "Gràcies a molta gent, Katuma ja és una realitat, l’eina ja està online i els primers grups de consum i productores ja la fan servir. Ara només ens cal el teu suport.",
+    "button": "Participa"
+  },
+  "principles": {
+    "title": "Els tres pilars",
+    "consumption": {
+      "title": "Consum de proximitat",
+      "body": "Com a eina per a potenciar la soberania alimentària i afavorir els productors locals que practiquen una agricultura diferent."
+    },
+    "platformcoop": {
+      "title": "Platform Coop",
+      "body": "Persones, grups de consum i productors de proximitat són els propietaris i decideixen el rumb de Katuma."
+    },
+    "software":{
+      "title": "Free software",
+      "body": "Perque també hem d'exercir els nostres drets digitals i el nostre projecte és un esforç col·lectiu i obert."
+    }
+  },
+  "journeys": {
+    "consumers": {
+      "title": "Consumidores",
+      "body": "Gràcies a un mapa que geolocalitza i visibilitza els grups de consum existents, es promou el contacte i l'adhesió de qualsevol persona, facilitant l'accés a un mercat alternatiu format per productores locals."
+    },
+    "groups": {
+      "title": "Grups de consum",
+      "body": "El productor manté la seva llista de productes i els grups que proveeix no s'han de preocupar de gestionar fulls de càlcul ni d'actualitzar cap preu."
+    },
+    "producers": {
+      "title": "Productores",
+      "body": "Ja no cal enviar llistats de preus actualitzats i rebre comandes cada setmana en diferents formats per WhatsApp, email, telèfon, etc."
+    }
+  },
+  "open-food-network": {
+    "title": "Sumem esforços",
+    "body": "Katuma es basa en el software lliure <a href='https://openfoodnetwork.org'>Open Food Network</a>, que ja s'aplica a Austràlia, Regne Unit, Canadà i França entre d'altres països. Els desenvolupadors que traballen a Katuma formen part del nucli del projecte."
+  },
+  "goteo": {
+    "title": "Ens ajudes a arribar més lluny?",
+    "body": "Amb aquesta campanya a Goteo seguirem desenvolupant Katuma, acompanyarem a grups i productores en la seva implantació i millorarem la nostra comunicació perquè Katuma arribi a tothom.",
+    "button": "Fes una donació",
+    "secondary-buton": "Entra"
   },
   "services": {
     "1": "1. Cerca el grup de consum més proper",
@@ -25,7 +74,7 @@
     "asociatebtn": "Fes-te sòcia!"
   },
   "footer": {
-    "github": "KATUMA es de còdi obert",
+    "github": "Katuma és codi lliure",
     "twitter": "Segueix-nos a Twitter",
     "facebook": "Segueix-nos a Facebook",
     "contact": "Contacta amb nosotres"


### PR DESCRIPTION
Added missing keys in the `ca` locale file.
The `ca` literals file was missing a couple of keys that made the landing page be presented as half localized in `es` and half in `ca`.

Please review semantics and syntax, thanks!
