### PR TITLE
Adding missing data-i18n in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
         <aside class="col-lg-4 offset-md-1">
           <h2 data-i18n="participate.title">Entre totes podem canviar les regles del consum</h2>
           <p data-i18n="participate.body">Gràcies a molta gent, Katuma ja és una realitat, l’eina ja està online i els primers grups de consum i productores ja la fan servir. Ara només ens cal el teu suport.</p>
-          <a onClick="trackOutboundLink('boton', 'click', 'Matchfunding2018-video','https://www.goteo.org/project/katuma'); return false;" class="button" href="https://www.goteo.org/project/katuma">Participa</a>
+          <a onClick="trackOutboundLink('boton', 'click', 'Matchfunding2018-video','https://www.goteo.org/project/katuma'); return false;" class="button" href="https://www.goteo.org/project/katuma" data-i18n="participate.button">Participa</a>
         </aside>
       </div>
     </div>
@@ -75,8 +75,8 @@
           <h2 data-i18n="principles.title">Els tres pilars</h2>
         </div>
         <div class="col-lg-4">
-          <h5>Consum de proximitat</h5>
-          <p>Com a eina per potenciar la sobirania alimentària i afavorir productors locals que fan una agricultura diferent.</p>
+          <h5 data-i18n="principles.consumption.title">Consum de proximitat</h5>
+          <p data-i18n="principles.consumption.body">Com a eina per potenciar la sobirania alimentària i afavorir productors locals que fan una agricultura diferent.</p>
         </div>
         <div class="col-lg-4">
           <h5 data-i18n="principles.platformcoop.title">Platform Coop</h5>
@@ -155,37 +155,37 @@
           <div class="col-lg-4 list">
             <a class="brand" href="#">Katuma</a>
             <div class="coopdevs">
-              <p>Impulsat per</p>
+              <p data-i18n="footer.developed.title">Impulsat per</p>
               <a href="http://coopdevs.org">
                 <img width="300" height="53.18" src="http://community.coopdevs.org/uploads/default/original/1X/8e49765a99d2ec95fde8d5f51468a3553226dcd0.png"/>
               </a>
             </div>
           </div>
           <div class="col-lg-3 list">
-            <h5>Nosaltres</h5>
+            <h5 data-i18n="footer.about.title">Nosaltres</h5>
             <div>
               <a href="https://github.com/coopdevs">
-                <i class="fa fa-github"></i> <span data-i18n="footer.github">Katuma és codi lliure</span>
+                <i class="fa fa-github"></i> <span data-i18n="footer.about.github">Katuma és codi lliure</span>
               </a>
             </div>
             <div>
               <a href="https://twitter.com/katuma_org">
-                <i class="fa fa-twitter"></i> <span data-i18n="footer.twitter">Segueix-nos a Twitter</span>
+                <i class="fa fa-twitter"></i> <span data-i18n="footer.about.twitter">Segueix-nos a Twitter</span>
               </a>
             </div>
             <div>
               <a href="https://www.facebook.com/katumaorg/">
-                <i class="fa fa-facebook"></i> <span data-i18n="footer.facebook">Segueix-nos a Facebook</span>
+                <i class="fa fa-facebook"></i> <span data-i18n="footer.about.facebook">Segueix-nos a Facebook</span>
               </a>
             </div>
             <div>
               <a href="http://community.coopdevs.org/tags/katuma">
-                <i class="fa fa-envelope"></i> <span data-i18n="footer.contact">Contacta amb nosaltres</span>
+                <i class="fa fa-envelope"></i> <span data-i18n="footer.about.contact">Contacta amb nosaltres</span>
               </a>
             </div>
          </div>
           <div id="languages" class="col-lg-3 list">
-            <h5>Idiomes</h5>
+            <h5 data-i18n="footer.languages.title">Idiomes</h5>
             <div>
               <a href="#" language="en">English</a>
             </div>
@@ -233,6 +233,6 @@
          });
       }
 
-      </script> 
+      </script>
   </body>
 </html>

--- a/locales/ca/translation.json
+++ b/locales/ca/translation.json
@@ -74,9 +74,18 @@
     "asociatebtn": "Fes-te sòcia!"
   },
   "footer": {
-    "github": "Katuma és codi lliure",
-    "twitter": "Segueix-nos a Twitter",
-    "facebook": "Segueix-nos a Facebook",
-    "contact": "Contacta amb nosotres"
+    "developed": {
+      "title": "Impulsat per"
+    },
+    "about": {
+      "title": "Nosaltres",
+      "github": "KATUMA es de còdi obert",
+      "twitter": "Segueix-nos a Twitter",
+      "facebook": "Segueix-nos a Facebook",
+      "contact": "Contacta amb nosotres"
+    },
+    "languages": {
+      "title": "Idiomes"
+    }
   }
 }

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,4 +1,9 @@
 {
+  "nav": {
+    "map": "Map",
+    "community": "Community",
+    "login": "Get in"
+  },
   "header": {
     "title": "KATUMA",
     "slogan": "Buy directly from local agro-ecological producers",
@@ -40,7 +45,7 @@
     }
   },
   "open-food-network": {
-    "title": "Sumamos esfuerzos",
+    "title": "Joint effort",
     "body": "Katuma is based on free <a href='https://openfoodnetwork.org'>Open Food Network</a> software, which is already applied in Australia, UK, Canada and France among other countries. Katuma's developers are core contributors of the project."
   },
   "goteo": {
@@ -50,9 +55,18 @@
     "secondary-button": "Get in"
   },
   "footer": {
-    "github": "Katuma is free software",
-    "twitter": "Follow us on Twitter",
-    "facebook": "Follow us on Facebook",
-    "contact": "Contact us"
+    "developed": {
+      "title": "Developed by"
+    },
+    "about": {
+      "title": "About us",
+      "github": "Katuma is free software",
+      "twitter": "Follow us on Twitter",
+      "facebook": "Follow us on Facebook",
+      "contact": "Contact us"
+    },
+    "languages": {
+      "title": "Languages"
+    }
   }
 }

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -54,9 +54,18 @@
     "secondary-button": "Entra"
   },
   "footer": {
-    "github": "Katuma es de código libre",
-    "twitter": "Síguenos en Twitter",
-    "facebook": "Síguenos en Facebook",
-    "contact": "Contacta con nosotros"
+    "developed": {
+      "title": "Impulsado por"
+    },
+    "about": {
+      "title": "Nosotros",
+      "github": "Katuma es de código libre",
+      "twitter": "Síguenos en Twitter",
+      "facebook": "Síguenos en Facebook",
+      "contact": "Contacta con nosotros"
+    },
+    "languages": {
+      "title": "Idiomas"
+    }
   }
 }


### PR DESCRIPTION
Some elements in the `index.html` page did not have the `data-i18n` tag, thus only showing the harcoded text in the html itself, even when changing the language. Note that some of the affected elements already had the key and literal in the locale files.

I took the liberty to add the tag to the affected elements and also a simple localized literal for the ones that still did not have it.