### PR TITLE
Add Docker config files and instructions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2.4-stretch
+WORKDIR /app
+ADD . /app/
+RUN set -uex; \
+    bundle install
+EXPOSE 4000
+CMD ["bundle", "exec", "jekyll", "serve"]

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ docker-compose up
 ```
 
 Now navigate to `http://127.0.0.1:4000/` to see the site.
+
+Keep in mind that any change in the `Gemfile` will require rebuilding the image running the command `docker-compose up --build`.

--- a/README.md
+++ b/README.md
@@ -14,4 +14,9 @@ This website is implemented with [Jekyllrb](https://jekyllrb.com/). After instal
 $ bundle exec jekyll serve
 ```
 
+If you want to develop using Docker instead, install [Docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/) and run:
+```shell
+docker-compose up
+```
+
 Now navigate to `http://127.0.0.1:4000/` to see the site.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  web:
+    build: .
+    volumes:
+     - .:/app
+    ports:
+     - "4000:4000"
+    command: "bundle exec jekyll serve --incremental --host 0.0.0.0"
+


### PR DESCRIPTION
In https://github.com/coopdevs/katuma-landing-page/issues/38 we mention that setting up the development  might not be easy for newcomers. This PR adds a Dockerfile and docker-compose files to allow people to start developing without having to worry about installing Ruby and the dependencies locally.

Just run `docker-compose up` and enjoy!