### PR TITLE
Fix call-to-action that refers to old matchfunding

### DIFF
--- a/locales/ca/features.json
+++ b/locales/ca/features.json
@@ -23,8 +23,8 @@
   },
   "help-us": {
     "title": "Ens ajudes a desenvolupar noves funcionalitats?",
-    "body": "Amb aquesta campanya a Goteo seguirem desenvolupant Katuma, acompanyarem a grups i productores en la seva implantació i millorarem la nostra comunicació perquè Katuma arribi a tothom.",
-    "button": "Fes una donació",
-    "secondary-buton": "Entra"
+    "body": "Fes que la teva entitat es faci socia i sumem esforços.",
+    "button": "Fes-te soci",
+    "secondary-buton": "Parlem"
   }
 }


### PR DESCRIPTION
That Goteo campaign no longer exists.