### PR TITLE
Upgrade jekyll to version 3.7.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,15 +8,15 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.7.3"
+gem "jekyll", ">= 3.7.4"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
 
 # If you have any plugins, put them here!
-group :jekyll_plugins do
-end
+# group :jekyll_plugins do
+# end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
This fixes the following vulnerability reported by Github:

CVE-2018-17567
moderate severity
Vulnerable versions: >= 3.7.0, < 3.7.4
Patched version: 3.7.4
Jekyll through 3.6.2, 3.7.x through 3.7.3, and 3.8.x through 3.8.3
allows attackers to access arbitrary files by specifying a symlink in
the "include" key in the "_config.yml" file.