### PR TITLE
Upgrade ffi to version 1.9.24

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", ">= 3.7.4"
+gem "jekyll", "~> 3.7.3"
+gem "ffi", ">= 1.9.24"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.


### PR DESCRIPTION
This fixes the following vulnerability reported by Github:

CVE-2018-1000201
Vulnerable versions: < 1.9.24
Patched version: 1.9.24
ruby-ffi version 1.9.23 and earlier has a DLL loading issue which can be
hijacked on Windows OS, when a Symbol is used as DLL name instead of
a String This vulnerability appears to have been fixed in v1.9.24 and
later.