### PR TITLE
Docker image with yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-stretch
+FROM ruby:2.6-alpine
 WORKDIR /app
 ADD . /app/
 RUN set -uex; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM ruby:2.6-alpine
+RUN apk update \
+    && apk upgrade \
+    && apk add --update --no-cache g++ musl-dev make libstdc++ yarn
 WORKDIR /app
 ADD . /app/
 RUN set -uex; \
-    bundle install
+    bundle install; \
+    yarn install
 EXPOSE 4000
 CMD ["bundle", "exec", "jekyll", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM ruby:2.6-alpine
 RUN apk update \
     && apk upgrade \
-    && apk add --update --no-cache g++ musl-dev make libstdc++ yarn
+    && apk add --update --no-cache \
+      g++ \
+      musl-dev \
+      make \
+      libstdc++ \
+      yarn
 WORKDIR /app
 ADD . /app/
 RUN set -uex; \


### PR DESCRIPTION
This should make Yarn available to our dev environment while at the same time upgrading Ruby to 2.6.5 and resulting in a slimmer docker image. This will also allow @lumie31 get going in https://github.com/coopdevs/katuma-landing-page/issues/10 in his windows machine.