### PR TITLE
Add missing VAT notice for producers

### DIFF
--- a/_includes/pricing/calculator-producers.html
+++ b/_includes/pricing/calculator-producers.html
@@ -35,6 +35,7 @@
       <div class="k-pricing__button-wrapper">
         <a class="button" data-i18n="pricing:try_it" href="https://app.katuma.org/register">Prova-ho</a>
         <small data-i18n="pricing:one_month_trial"></small>
+        <small data-i18n="pricing:vat_not_included"></small>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I forgot about it in https://github.com/coopdevs/katuma-landing-page/pull/79.